### PR TITLE
Deactivate SCIM by default

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -74,7 +74,7 @@ Copy the built artifact into the directory `${keycloak.home}/standalone/deployme
 
 1. Select the `SCIM` link and you should see the following view:   
    ![theme-settings](images/service-provider-config.png)
-2. You can disable SCIM for each realm separately and the `ServiceProvider` configurations as defined in RFC7643
+2. You can enable SCIM for each realm separately and the `ServiceProvider` configurations as defined in RFC7643
 3. You may restrict access to the SCIM-endpoints for each separate realm by allowing users only access if they have been
    identified by a specific client. If no clients are selected any client is authorized to access the SCIM endpoints:  
    ![theme-settings](images/service-provider-auth-config.png)

--- a/README.MD
+++ b/README.MD
@@ -69,6 +69,7 @@ Copy the built artifact into the directory `${keycloak.home}/standalone/deployme
 2. Now open the web admin console of keycloak open the realm settings and select the `Themes` tab and select the `scim`
    theme for the admin console. Now reload the browser page and the `SCIM` menu link should be visible.
    ![theme-settings](images/theme-setting.png)
+3. The SCIM endpoints will be deactivated by default. To activate it for a realm toggle the "SCIM enabled" switch under the SCIM menu link.
 
 ## What is configurable?
 

--- a/scim-for-keycloak-server/src/main/java/de/captaingoldfish/scim/sdk/keycloak/services/ScimServiceProviderService.java
+++ b/scim-for-keycloak-server/src/main/java/de/captaingoldfish/scim/sdk/keycloak/services/ScimServiceProviderService.java
@@ -57,7 +57,7 @@ public class ScimServiceProviderService extends AbstractService
   {
     return ScimServiceProviderEntity.builder()
                                     .realmId(getKeycloakSession().getContext().getRealm().getId())
-                                    .enabled(true)
+                                    .enabled(false)
                                     .filterSupported(true)
                                     .filterMaxResults(50)
                                     .sortSupported(true)
@@ -98,7 +98,7 @@ public class ScimServiceProviderService extends AbstractService
 
     scimServiceProviderEntity.setEnabled(Optional.ofNullable(serviceProvider.get("enabled"))
                                                  .map(JsonNode::booleanValue)
-                                                 .orElse(true));
+                                                 .orElse(false));
     scimServiceProviderEntity.setFilterSupported(serviceProvider.getFilterConfig().isSupported());
     scimServiceProviderEntity.setFilterMaxResults(serviceProvider.getFilterConfig().getMaxResults());
     scimServiceProviderEntity.setSortSupported(serviceProvider.getSortConfig().isSupported());

--- a/scim-for-keycloak-server/src/test/java/de/captaingoldfish/scim/sdk/keycloak/scim/AbstractScimEndpointTest.java
+++ b/scim-for-keycloak-server/src/test/java/de/captaingoldfish/scim/sdk/keycloak/scim/AbstractScimEndpointTest.java
@@ -1,0 +1,28 @@
+package de.captaingoldfish.scim.sdk.keycloak.scim;
+
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import de.captaingoldfish.scim.sdk.common.resources.ServiceProvider;
+import de.captaingoldfish.scim.sdk.keycloak.scim.administration.ServiceProviderResource;
+import de.captaingoldfish.scim.sdk.keycloak.setup.KeycloakScimManagementTest;
+import org.junit.jupiter.api.BeforeEach;
+
+
+/**
+ * Automatically enables the SCIM Endpoint for the default realm.
+ *
+ * @author Mario Siegenthaler
+ * @since 07.08.2020
+ */
+public class AbstractScimEndpointTest extends KeycloakScimManagementTest
+{
+
+  @BeforeEach
+  public void enableScim()
+  {
+    ServiceProvider serviceProvider = getScimEndpoint().getResourceEndpoint().getServiceProvider();
+    serviceProvider.set("enabled", BooleanNode.valueOf(true));
+    ServiceProviderResource serviceProviderResource = getScimEndpoint().administerResources()
+                                                                       .getServiceProviderResource();
+    serviceProviderResource.updateServiceProviderConfig(serviceProvider.toString());
+  }
+}

--- a/scim-for-keycloak-server/src/test/java/de/captaingoldfish/scim/sdk/keycloak/scim/handler/GroupHandlerTest.java
+++ b/scim-for-keycloak-server/src/test/java/de/captaingoldfish/scim/sdk/keycloak/scim/handler/GroupHandlerTest.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
 
+import de.captaingoldfish.scim.sdk.keycloak.scim.AbstractScimEndpointTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -35,7 +36,7 @@ import lombok.extern.slf4j.Slf4j;
  * @since 27.08.2020
  */
 @Slf4j
-public class GroupHandlerTest extends KeycloakScimManagementTest
+public class GroupHandlerTest extends AbstractScimEndpointTest
 {
 
   /**

--- a/scim-for-keycloak-server/src/test/java/de/captaingoldfish/scim/sdk/keycloak/scim/handler/RealmRoleHandlerTest.java
+++ b/scim-for-keycloak-server/src/test/java/de/captaingoldfish/scim/sdk/keycloak/scim/handler/RealmRoleHandlerTest.java
@@ -22,7 +22,7 @@ import de.captaingoldfish.scim.sdk.common.utils.JsonHelper;
 import de.captaingoldfish.scim.sdk.keycloak.custom.resources.ChildRole;
 import de.captaingoldfish.scim.sdk.keycloak.custom.resources.RealmRole;
 import de.captaingoldfish.scim.sdk.keycloak.custom.resources.RoleAssociate;
-import de.captaingoldfish.scim.sdk.keycloak.setup.KeycloakScimManagementTest;
+import de.captaingoldfish.scim.sdk.keycloak.scim.AbstractScimEndpointTest;
 import de.captaingoldfish.scim.sdk.keycloak.setup.RequestBuilder;
 import lombok.extern.slf4j.Slf4j;
 
@@ -32,7 +32,7 @@ import lombok.extern.slf4j.Slf4j;
  * @since 16.08.2020
  */
 @Slf4j
-public class RealmRoleHandlerTest extends KeycloakScimManagementTest
+public class RealmRoleHandlerTest extends AbstractScimEndpointTest
 {
 
   public static final String ROLES_ENDPOINT = "/RealmRoles";

--- a/scim-for-keycloak-server/src/test/java/de/captaingoldfish/scim/sdk/keycloak/scim/handler/UserHandlerTest.java
+++ b/scim-for-keycloak-server/src/test/java/de/captaingoldfish/scim/sdk/keycloak/scim/handler/UserHandlerTest.java
@@ -21,7 +21,7 @@ import de.captaingoldfish.scim.sdk.common.resources.ServiceProvider;
 import de.captaingoldfish.scim.sdk.common.resources.User;
 import de.captaingoldfish.scim.sdk.common.resources.complex.ChangePasswordConfig;
 import de.captaingoldfish.scim.sdk.keycloak.scim.ScimConfigurationBridge;
-import de.captaingoldfish.scim.sdk.keycloak.setup.KeycloakScimManagementTest;
+import de.captaingoldfish.scim.sdk.keycloak.scim.AbstractScimEndpointTest;
 import de.captaingoldfish.scim.sdk.keycloak.setup.RequestBuilder;
 import de.captaingoldfish.scim.sdk.server.endpoints.ResourceEndpoint;
 import lombok.extern.slf4j.Slf4j;
@@ -32,7 +32,7 @@ import lombok.extern.slf4j.Slf4j;
  * @since 18.08.2020
  */
 @Slf4j
-public class UserHandlerTest extends KeycloakScimManagementTest
+public class UserHandlerTest extends AbstractScimEndpointTest
 {
 
   /**


### PR DESCRIPTION
This PR deactivates SCIM on new realms by default and prevents that SCIM is automatically active on all realm after installing the extension.
This ensures that the administrator doesn't activate SCIM by accident, since it might be "invisible" when the admin theme is not changed.