### PR TITLE
Protect the SCIM-API with the realm role scim-api-user

### DIFF
--- a/scim-for-keycloak-server/src/main/java/de/captaingoldfish/scim/sdk/keycloak/provider/RealmRoleInitializer.java
+++ b/scim-for-keycloak-server/src/main/java/de/captaingoldfish/scim/sdk/keycloak/provider/RealmRoleInitializer.java
@@ -38,6 +38,11 @@ public class RealmRoleInitializer
   public static final String SCIM_ADMIN_ROLE = "scim-admin";
 
   /**
+   * the role that is required to access the SCIM api
+   */
+  public static final String SCIM_API_USER_ROLE = "scim-api-user";
+
+  /**
    * initializes the {@link #SCIM_ADMIN_ROLE} on all existing realms if not present and makes sure that the role
    * will also be added to all new created realms
    */
@@ -115,7 +120,7 @@ public class RealmRoleInitializer
         if (client.getRole(SCIM_ADMIN_ROLE) == null)
         {
           log.info("configuring realm {} for SCIM", realm.getName());
-          addRealmAdminRoles(manager, realm);
+          addRealmRoles(manager, realm);
         }
       }
     });
@@ -132,7 +137,7 @@ public class RealmRoleInitializer
     addMasterAdminRoles(manager, realm);
     if (!realm.getName().equals(Config.getAdminRealm()))
     {
-      addRealmAdminRoles(manager, realm);
+      addRealmRoles(manager, realm);
     }
   }
 
@@ -151,11 +156,12 @@ public class RealmRoleInitializer
   /**
    * will add the role {@link #SCIM_ADMIN_ROLE} to the admin-user role of the given realm
    */
-  private static void addRealmAdminRoles(RealmManager manager, RealmModel realm)
+  private static void addRealmRoles(RealmManager manager, RealmModel realm)
   {
     ClientModel client = realm.getClientByClientId(manager.getRealmAdminClientId(realm));
     RoleModel admin = client.getRole(AdminRoles.REALM_ADMIN);
     addScimAdminRole(client, admin);
+    addScimApiUserRole(realm);
   }
 
   /**
@@ -174,4 +180,17 @@ public class RealmRoleInitializer
     parent.addCompositeRole(role);
     log.info("added role '{}' as composite member to role '{}'", SCIM_ADMIN_ROLE, parent.getName());
   }
+
+  /**
+   * adds the {@link #SCIM_API_USER_ROLE} to the given realm.
+   *
+   * @param realm the client to which the role {@link #SCIM_API_USER_ROLE} should be added
+   */
+  private static void addScimApiUserRole(RealmModel realm)
+  {
+    RoleModel role = realm.addRole(SCIM_API_USER_ROLE);
+    log.info("created role '{}'", SCIM_API_USER_ROLE);
+    role.setDescription("${role_" + SCIM_API_USER_ROLE + "}");
+  }
+
 }

--- a/scim-for-keycloak-server/src/main/java/de/captaingoldfish/scim/sdk/keycloak/services/ScimResourceTypeService.java
+++ b/scim-for-keycloak-server/src/main/java/de/captaingoldfish/scim/sdk/keycloak/services/ScimResourceTypeService.java
@@ -1,11 +1,7 @@
 package de.captaingoldfish.scim.sdk.keycloak.services;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -19,6 +15,8 @@ import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
+import de.captaingoldfish.scim.sdk.keycloak.provider.RealmRoleInitializer;
+import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
@@ -37,6 +35,7 @@ import de.captaingoldfish.scim.sdk.server.schemas.custom.EndpointControlFeature;
 import de.captaingoldfish.scim.sdk.server.schemas.custom.ResourceTypeAuthorization;
 import de.captaingoldfish.scim.sdk.server.schemas.custom.ResourceTypeFeatures;
 import lombok.extern.slf4j.Slf4j;
+import org.keycloak.services.managers.RealmManager;
 
 
 /**
@@ -103,10 +102,12 @@ public class ScimResourceTypeService extends AbstractService
    */
   private ScimResourceTypeEntity createNewResourceTypeEntry(ResourceType resourceType, RealmModel realmModel)
   {
+    List<RoleEntity> roles = getRoles(Collections.singleton(RealmRoleInitializer.SCIM_API_USER_ROLE));
     ScimResourceTypeEntity scimResourceTypeEntity = ScimResourceTypeEntity.builder()
                                                                           .realmId(realmModel.getId())
                                                                           .name(resourceType.getName())
                                                                           .created(Instant.now())
+                                                                          .endpointRoles(roles)
                                                                           .build();
     getEntityManager().persist(scimResourceTypeEntity);
     setValuesOfEntity(scimResourceTypeEntity, resourceType);


### PR DESCRIPTION
This PR creates a realm role "scim-api-user" and by default requires that for calls the the SCIM APIs.