### PR TITLE
Add realm-management role for api access

### DIFF
--- a/scim-for-keycloak-server/src/main/java/de/captaingoldfish/scim/sdk/keycloak/entities/ScimServiceProviderEntity.java
+++ b/scim-for-keycloak-server/src/main/java/de/captaingoldfish/scim/sdk/keycloak/entities/ScimServiceProviderEntity.java
@@ -131,6 +131,9 @@ public class ScimServiceProviderEntity implements Serializable
   @Column(name = "BULK_MAX_PAYLOAD_SIZE")
   private long bulkMaxPayloadSize;
 
+  @Column(name = "REQUIRE_SCIM_API_USER_ROLE")
+  private boolean requireScimApiUserRole;
+
   /**
    * the clients that are allowed to access the SCIM endpoints. OPTIONAL
    */
@@ -166,6 +169,7 @@ public class ScimServiceProviderEntity implements Serializable
                                    boolean bulkSupported,
                                    int bulkMaxOperations,
                                    long bulkMaxPayloadSize,
+                                   boolean requireScimApiUserRole,
                                    List<ClientEntity> authorizedClients,
                                    Instant created,
                                    Instant lastModified)
@@ -181,6 +185,7 @@ public class ScimServiceProviderEntity implements Serializable
     this.bulkSupported = bulkSupported;
     this.bulkMaxOperations = bulkMaxOperations;
     this.bulkMaxPayloadSize = bulkMaxPayloadSize;
+    this.requireScimApiUserRole = requireScimApiUserRole;
     this.authorizedClients = Optional.ofNullable(authorizedClients).orElse(new ArrayList<>());
     this.created = created;
     this.lastModified = lastModified;

--- a/scim-for-keycloak-server/src/main/java/de/captaingoldfish/scim/sdk/keycloak/provider/RealmRoleInitializer.java
+++ b/scim-for-keycloak-server/src/main/java/de/captaingoldfish/scim/sdk/keycloak/provider/RealmRoleInitializer.java
@@ -38,6 +38,12 @@ public class RealmRoleInitializer
   public static final String SCIM_ADMIN_ROLE = "scim-admin";
 
   /**
+   * the role that is required to access the SCIM rest api (and read/mutate resources)
+   */
+  public static final String SCIM_API_USER_ROLE = "scim-api-user";
+
+
+  /**
    * initializes the {@link #SCIM_ADMIN_ROLE} on all existing realms if not present and makes sure that the role
    * will also be added to all new created realms
    */
@@ -156,6 +162,7 @@ public class RealmRoleInitializer
     ClientModel client = realm.getClientByClientId(manager.getRealmAdminClientId(realm));
     RoleModel admin = client.getRole(AdminRoles.REALM_ADMIN);
     addScimAdminRole(client, admin);
+    addScimApiUserRole(client, admin);
   }
 
   /**
@@ -173,5 +180,20 @@ public class RealmRoleInitializer
     role.setDescription("${role_" + SCIM_ADMIN_ROLE + "}");
     parent.addCompositeRole(role);
     log.info("added role '{}' as composite member to role '{}'", SCIM_ADMIN_ROLE, parent.getName());
+  }
+
+
+  /**
+   * adds the {@link #SCIM_API_USER_ROLE} to the given client.
+   *
+   * @param client the client to which the role {@link #SCIM_API_USER_ROLE} should be added
+   */
+  private static void addScimApiUserRole(ClientModel client, RoleModel parent)
+  {
+    RoleModel role = client.addRole(SCIM_API_USER_ROLE);
+    log.info("created role '{}'", SCIM_API_USER_ROLE);
+    role.setDescription("${role_" + SCIM_API_USER_ROLE + "}");
+    parent.addCompositeRole(role);
+    log.info("added role '{}' as composite member to role '{}'", SCIM_API_USER_ROLE, parent.getName());
   }
 }

--- a/scim-for-keycloak-server/src/main/java/de/captaingoldfish/scim/sdk/keycloak/services/ScimServiceProviderService.java
+++ b/scim-for-keycloak-server/src/main/java/de/captaingoldfish/scim/sdk/keycloak/services/ScimServiceProviderService.java
@@ -58,6 +58,7 @@ public class ScimServiceProviderService extends AbstractService
     return ScimServiceProviderEntity.builder()
                                     .realmId(getKeycloakSession().getContext().getRealm().getId())
                                     .enabled(true)
+                                    .requireScimApiUserRole(true)
                                     .filterSupported(true)
                                     .filterMaxResults(50)
                                     .sortSupported(true)
@@ -99,6 +100,9 @@ public class ScimServiceProviderService extends AbstractService
     scimServiceProviderEntity.setEnabled(Optional.ofNullable(serviceProvider.get("enabled"))
                                                  .map(JsonNode::booleanValue)
                                                  .orElse(true));
+    scimServiceProviderEntity.setRequireScimApiUserRole(Optional.ofNullable(serviceProvider.get("requireScimApiUserRole"))
+                                                                .map(JsonNode::booleanValue)
+                                                                .orElse(true));
     scimServiceProviderEntity.setFilterSupported(serviceProvider.getFilterConfig().isSupported());
     scimServiceProviderEntity.setFilterMaxResults(serviceProvider.getFilterConfig().getMaxResults());
     scimServiceProviderEntity.setSortSupported(serviceProvider.getSortConfig().isSupported());
@@ -250,6 +254,7 @@ public class ScimServiceProviderService extends AbstractService
     {
       // now adding custom attributes not that are not defined by SCIM but are used within the web-admin console
       serviceProvider.set("enabled", BooleanNode.valueOf(entity.isEnabled()));
+      serviceProvider.set("requireScimApiUserRole", BooleanNode.valueOf(entity.isRequireScimApiUserRole()));
 
       ArrayNode arrayNode = new ArrayNode(JsonNodeFactory.instance);
       entity.getAuthorizedClients().stream().map(ClientEntity::getClientId).forEach(arrayNode::add);

--- a/scim-for-keycloak-server/src/main/resources/META-INF/scim-changelog.xml
+++ b/scim-for-keycloak-server/src/main/resources/META-INF/scim-changelog.xml
@@ -134,4 +134,10 @@
 
     </changeSet>
 
+    <changeSet author="mario siegenthaler" id="scim-sdk-1.0.1">
+        <addColumn tableName="SCIM_SERVICE_PROVIDER">
+            <column name="REQUIRE_SCIM_API_USER_ROLE" type="BOOLEAN" defaultValue="false" />
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>

--- a/scim-for-keycloak-server/src/main/resources/theme/scim/admin/resources/partials/service-provider-authorization.html
+++ b/scim-for-keycloak-server/src/main/resources/theme/scim/admin/resources/partials/service-provider-authorization.html
@@ -8,6 +8,19 @@
         <kc-tabs-service-provider></kc-tabs-service-provider>
 
         <form class="form-horizontal" name="serviceProviderForm" novalidate>
+            <div class="form-group">
+                <label class="col-md-2 control-label"
+                       for="requireScimApiUserRole">{{:: 'service.provider.requireScimApiUserRole' | translate }}</label>
+                <div class="col-md-6">
+                    <input data-ng-model="serviceProvider.requireScimApiUserRole"
+                           id="requireScimApiUserRole"
+                           name="requireScimApiUserRole"
+                           off-text="{{:: 'offText' | translate}}"
+                           on-text="{{:: 'onText' | translate}}"
+                           onoffswitch/>
+                </div>
+                <kc-tooltip>{{:: 'service.provider.requireScimApiUserRole.tooltip' | translate}}</kc-tooltip>
+            </div>
 
             <div class="form-group">
                 <label class="col-md-2 control-label" class="control-label">


### PR DESCRIPTION
I wasn't completely happy with the approach from #10 (this PR replaces #10). While it works fine it has the danger that if the admin deletes the realm role the API would be unprotected again. This would be unexpected to the admin (at least to me).

So here's a new take:
* add a realm-management client role for api usage. Makes more sense that a realm-level role anyway
* protect all api access with that role centrally in the Authentication class (same location where the client id is checked as well)
* provide a toggle to turn that behaviour off. By default it would be on. By turning it off you'd still be able to do everything the same way as before (even no-auth)
* add a db migration that turns the protection off on existing configurations. That way everything stays as it was before.

The implementation isn't fully done yet, e.g. I've not yet tested the config UI or added tests (or fixed integration tests).

I like this approach better as it is less intrusive and it's harder for the admin to accidentally compromise security. What do you think? 