### PR TITLE
Support creating users with a password

### DIFF
--- a/scim-for-keycloak-server/src/main/java/de/captaingoldfish/scim/sdk/keycloak/scim/handler/UserHandler.java
+++ b/scim-for-keycloak-server/src/main/java/de/captaingoldfish/scim/sdk/keycloak/scim/handler/UserHandler.java
@@ -73,6 +73,10 @@ public class UserHandler extends ResourceHandler<User>
     }
     UserModel userModel = keycloakSession.users().addUser(keycloakSession.getContext().getRealm(), username);
     userModel = userToModel(user, userModel);
+    if (isChangePasswordSupported() && user.getPassword().isPresent())
+    {
+      setPassword(keycloakSession, user.getPassword().get(), userModel);
+    }
     User newUser = modelToUser(userModel);
     {
       ScimAdminEventBuilder adminEventAuditer = ((ScimKeycloakContext)context).getAdminEventAuditer();


### PR DESCRIPTION
This allows for creating users with a password by setting the "password" attribute
if "Change Password Supported" is true, similar to how updateResource handles it