### PR TITLE
Updating liquibase changelog files in custom extensions with entities

### DIFF
--- a/scim-for-keycloak-server/src/main/resources/META-INF/scim-changelog.xml
+++ b/scim-for-keycloak-server/src/main/resources/META-INF/scim-changelog.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
-<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog src/main/resources/META-INF/dbchangelog-3.9.xsd">
-
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" 
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    
     <changeSet author="pascal knueppel" id="scim-sdk-1.0">
 
         <createTable tableName="SCIM_SERVICE_PROVIDER">


### PR DESCRIPTION
Currently the **scim-for-keycloak artifact** breaks the keycloak server due to corrupt liquibase changelog file
This pull request updates the file
cc @Captain-P-Goldfish 